### PR TITLE
Fixed the configuration of the Console in Docker Compose

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -75,9 +75,9 @@ services:
       CONSOLE_CONFIG_FILE: |
         kafka:
           brokers: ["broker1:9992","broker2:9993","broker3:9994"]
-          schemaRegistry:
-            enabled: false
-        connect:
+        schemaRegistry:
+          enabled: false
+        kafkaConnect:
           enabled: false
     ports:
       - "8080:8080"


### PR DESCRIPTION
The Console on startup (when running `docker compose` is throwing a parsing error of the configuration:

`console-1  | {"time":"2025-09-10T07:46:44.978007106Z","level":"ERROR","msg":"failed to load yaml config","error":"failed to validate YAML config (strict validation): decoding failed due to the following error(s):\n\n'kafka' has invalid keys: schemaRegistry\n'' has invalid keys: connect"}`

I was able to run it successfully, after applying the changes in this PR.

The indentation of the `schemaRegistry` seems to be incorrect and there is no `connect` option within `kafka:`.

Please have a look if it helps.